### PR TITLE
[check_res_dec] Fixing compile WER script

### DIFF
--- a/RESULTS
+++ b/RESULTS
@@ -1,6 +1,6 @@
 #!/bin/bash
-for x in exp/*/decod*; do [ -d $x ] && echo $x | grep "${1:-.*}" >/dev/null && grep WER $x/wer_* 2>/dev/null | ./best_wer.sh; done
-for x in exp/*/decod*; do [ -d $x ] && echo $x | grep "${1:-.*}" >/dev/null && grep Sum $x/score_*/*.sys 2>/dev/null | ./best_wer.sh; done
+for x in $(find $1 -type d -name "decode_*"); do [ -d $x ] && echo $x | grep "${1:-.*}" >/dev/null && grep WER $x/wer_* 2>/dev/null | ./best_wer.sh; done
+for x in $(find $1 -type d -name "decode_*"); do [ -d $x ] && echo $x | grep "${1:-.*}" >/dev/null && grep Sum $x/*score_*/*.sys 2>/dev/null | ./best_wer.sh; done
 exit 0
 
 

--- a/check_res_dec.sh
+++ b/check_res_dec.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 for x in $1; do [ -d $x ] && echo $x | grep "${1:-.*}" >/dev/null && grep WER $x/wer_* 2>/dev/null | ./best_wer.sh; done
-for x in $1; do [ -d $x ] && echo $x | grep "${1:-.*}" >/dev/null && grep Sum $x/score_*/*.sys 2>/dev/null | ./best_wer.sh; done
+for x in $1; do [ -d $x ] && echo $x | grep "${1:-.*}" >/dev/null && grep Sum $x/*score_*/*.sys 2>/dev/null | ./best_wer.sh; done
 exit 0
 
 


### PR DESCRIPTION
Existing one didn't seem to work for me. This script also extends functionality with ability to pass multiple exp directories for which best WER are compiled. 
e.g. `./check_res_dec.sh exp/AMI_LSTM_v1 exp/AMI_liGRU_v1` or `./check_res_dec.sh exp/AMI_LSTM*` 