### PR TITLE
Multi-threaded decoding via kaldi support

### DIFF
--- a/kaldi_decoding_scripts/decode_dnn.sh
+++ b/kaldi_decoding_scripts/decode_dnn.sh
@@ -26,6 +26,7 @@ cd $decoding_script_folder
 
 
 ## Begin configuration section
+num_threads=1
 stage=0
 cmd=utils/run.pl
 

--- a/kaldi_decoding_scripts/decode_dnn.sh
+++ b/kaldi_decoding_scripts/decode_dnn.sh
@@ -29,8 +29,6 @@ cd $decoding_script_folder
 stage=0
 cmd=utils/run.pl
 
-num_threads=1
-
 
 echo "$0 $@"  # Print the command line for logging
 
@@ -82,7 +80,7 @@ for ck_data in "${arr_ck[@]}"
 do
 
     finalfeats="ark,s,cs: cat $ck_data |"
-    latgen-faster-mapped --min-active=$min_active --max-active=$max_active --max-mem=$max_mem --beam=$beam --lattice-beam=$latbeam --acoustic-scale=$acwt --allow-partial=true --word-symbol-table=$graphdir/words.txt $alidir/final.mdl $graphdir/HCLG.fst "$finalfeats" "ark:|gzip -c > $dir/lat.$JOB.gz" &> $dir/log/decode.$JOB.log &
+    latgen-faster-mapped$thread_string --min-active=$min_active --max-active=$max_active --max-mem=$max_mem --beam=$beam --lattice-beam=$latbeam --acoustic-scale=$acwt --allow-partial=true --word-symbol-table=$graphdir/words.txt $alidir/final.mdl $graphdir/HCLG.fst "$finalfeats" "ark:|gzip -c > $dir/lat.$JOB.gz" &> $dir/log/decode.$JOB.log &
     JOB=$((JOB+1))
 done
 wait


### PR DESCRIPTION
Further to discussion on #31, just including the smallest change that would make this viable. Should be quite important to have while working with any reasonable-size dataset. 

Right now `num_threads` is a hardcoded variable in `decode_dnn.sh` 