### PR TITLE
Refactor run nn

### DIFF
--- a/core.py
+++ b/core.py
@@ -170,6 +170,7 @@ def run_nn_refac01(data_name,data_set,data_end_index,fea_dict,lab_dict,arch_dict
                  out_file=info_file.replace('.info','_'+arch_dict[net][0]+'.pkl')
                  torch.save(checkpoint, out_file)
     
+    from data_io import read_lab_fea_refac01 as read_lab_fea
     config = _read_chunk_specific_config(cfg_file)
     _initialize_random_seed(config)
     

--- a/core.py
+++ b/core.py
@@ -192,7 +192,8 @@ def run_nn_refac01(data_name,data_set,data_end_index,fea_dict,lab_dict,arch_dict
     if processed_first:
         shared_list = list()
         p = _read_next_chunk_into_shared_list_with_subprocess(read_lab_fea, shared_list, cfg_file, is_production, output_folder, wait_for_process=True)
-        data_name, data_end_index, fea_dict, lab_dict, arch_dict, data_set = _extract_data_from_shared_list(shared_list)
+        data_name, data_end_index, fea_dict, lab_dict, arch_dict, data_set_dict = _extract_data_from_shared_list(shared_list)
+        data_set_dict = np.column_stack((data_set_dict['input'], data_set_dict['ref']))
         data_set = _convert_numpy_to_torch(data_set, save_gpumem, use_cuda)
     shared_list = list()
     data_loading_process = _read_next_chunk_into_shared_list_with_subprocess(read_lab_fea, shared_list, next_config_file, is_production, output_folder, wait_for_process=False)
@@ -247,7 +248,8 @@ def run_nn_refac01(data_name,data_set,data_end_index,fea_dict,lab_dict,arch_dict
     _write_info_file(info_file, to_do, loss_tot, err_tot, elapsed_time_chunk)
     if not data_loading_process is None:
         data_loading_process.join()
-    data_name, data_end_index, fea_dict, lab_dict, arch_dict, data_set = _extract_data_from_shared_list(shared_list)
+    data_name, data_end_index, fea_dict, lab_dict, arch_dict, data_set_dict = _extract_data_from_shared_list(shared_list)
+    data_set = np.column_stack((data_set_dict['input'], data_set_dict['ref']))
     data_set = _convert_numpy_to_torch(data_set, save_gpumem, use_cuda)
     return [data_name,data_set,data_end_index,fea_dict,lab_dict,arch_dict]
 

--- a/core.py
+++ b/core.py
@@ -171,6 +171,7 @@ def run_nn_refac01(data_name,data_set,data_end_index,fea_dict,lab_dict,arch_dict
                  torch.save(checkpoint, out_file)
     
     from data_io import read_lab_fea_refac01 as read_lab_fea
+    from utils import forward_model_refac01 as forward_model
     config = _read_chunk_specific_config(cfg_file)
     _initialize_random_seed(config)
     

--- a/core.py
+++ b/core.py
@@ -21,6 +21,234 @@ import torch
 from data_io import read_lab_fea,open_or_fd,write_mat
 from utils import shift
 
+def run_nn_refac01(data_name,data_set,data_end_index,fea_dict,lab_dict,arch_dict,cfg_file,processed_first,next_config_file,dry_run=False):
+    def _read_chunk_specific_config(cfg_file):
+        if not(os.path.exists(cfg_file)):
+            sys.stderr.write('ERROR: The config file %s does not exist!\n'%(cfg_file))
+            sys.exit(0)
+        else:
+            config = configparser.ConfigParser()
+            config.read(cfg_file)
+        return config
+    def _read_next_chunk_into_shared_list_with_subprocess(read_lab_fea, shared_list, cfg_file, is_production, output_folder, wait_for_process):
+        p=threading.Thread(target=read_lab_fea, args=(cfg_file,is_production,shared_list,output_folder,))
+        p.start()
+        if wait_for_process:
+            p.join()
+            return None 
+        else:
+            return p
+    def _extract_data_from_shared_list(shared_list):
+        data_name=shared_list[0]
+        data_end_index=shared_list[1]
+        fea_dict=shared_list[2]
+        lab_dict=shared_list[3]
+        arch_dict=shared_list[4]
+        data_set=shared_list[5]
+        return data_name, data_end_index, fea_dict, lab_dict, arch_dict, data_set
+    def _get_batch_size_from_config(config, to_do):
+        if to_do=='train':
+            batch_size=int(config['batches']['batch_size_train'])
+        elif to_do=='valid':
+            batch_size=int(config['batches']['batch_size_valid'])
+        elif to_do=='forward':
+            batch_size=1
+        return batch_size
+    def _initialize_random_seed(config):
+        seed=int(config['exp']['seed'])
+        torch.manual_seed(seed)
+        random.seed(seed)
+        np.random.seed(seed)
+    def _convert_numpy_to_torch(data_set, save_gpumem, use_cuda):
+        if not(save_gpumem) and use_cuda:
+            data_set=torch.from_numpy(data_set).float().cuda()
+        else:
+            data_set=torch.from_numpy(data_set).float()
+        return data_set
+    def _load_model_and_optimizer(fea_dict,model,config,arch_dict,use_cuda,multi_gpu,to_do):
+        inp_out_dict = fea_dict
+        nns, costs = model_init(inp_out_dict,model,config,arch_dict,use_cuda,multi_gpu,to_do)
+        optimizers = optimizer_init(nns,config,arch_dict)
+        for net in nns.keys():
+            pt_file_arch=config[arch_dict[net][0]]['arch_pretrain_file']
+            if pt_file_arch!='none':        
+                if use_cuda:
+                    checkpoint_load = torch.load(pt_file_arch)
+                else:
+                    checkpoint_load = torch.load(pt_file_arch, map_location='cpu')
+                nns[net].load_state_dict(checkpoint_load['model_par'])
+                optimizers[net].load_state_dict(checkpoint_load['optimizer_par'])
+                optimizers[net].param_groups[0]['lr']=float(config[arch_dict[net][0]]['arch_lr']) # loading lr of the cfg file for pt
+            if multi_gpu:
+                nns[net] = torch.nn.DataParallel(nns[net])
+        return nns, costs, optimizers, inp_out_dict
+    def _open_forward_output_files_and_get_file_handles(forward_outs, require_decodings, info_file, output_folder):
+        post_file={}
+        for out_id in range(len(forward_outs)):
+            if require_decodings[out_id]:
+                out_file=info_file.replace('.info','_'+forward_outs[out_id]+'_to_decode.ark')
+            else:
+                out_file=info_file.replace('.info','_'+forward_outs[out_id]+'.ark')
+            post_file[forward_outs[out_id]]=open_or_fd(out_file,output_folder,'wb')
+        return post_file
+    def _get_batch_config(data_set, seq_model, to_do, data_name, batch_size):
+        N_snt = None
+        N_ex_tr = None
+        N_batches = None
+        if seq_model or to_do=='forward':
+            N_snt=len(data_name)
+            N_batches=int(N_snt/batch_size)
+        else:
+            N_ex_tr=data_set.shape[0]
+            N_batches=int(N_ex_tr/batch_size)
+        return N_snt, N_ex_tr, N_batches
+    def _prepare_input(snt_index, batch_size, inp_dim, beg_snt, data_end_index, beg_batch, end_batch, seq_model, arr_snt_len, data_set, use_cuda):
+        max_len=0
+        if seq_model:
+            max_len = int(max(arr_snt_len[snt_index:snt_index+batch_size]))  
+            inp = torch.zeros(max_len,batch_size,inp_dim).contiguous()
+            for k in range(batch_size):
+                snt_len = data_end_index[snt_index]-beg_snt
+                N_zeros = max_len-snt_len
+                # Appending a random number of initial zeros, tge others are at the end. 
+                N_zeros_left = random.randint(0,N_zeros)
+                # randomizing could have a regularization effect
+                inp[N_zeros_left:N_zeros_left+snt_len,k,:] = data_set[beg_snt:beg_snt+snt_len,:]
+                beg_snt = data_end_index[snt_index]
+                snt_index = snt_index+1
+        else:
+            if to_do != 'forward':
+                inp = data_set[beg_batch:end_batch,:].contiguous()
+            else:
+                snt_len = data_end_index[snt_index]-beg_snt
+                inp = data_set[beg_snt:beg_snt+snt_len,:].contiguous()
+                beg_snt = data_end_index[snt_index]
+                snt_index = snt_index+1
+        if use_cuda:
+            inp=inp.cuda()
+        return inp, max_len, snt_len, beg_snt, snt_index
+    def _forward_data_through_network(dry_run, fea_dict,lab_dict,arch_dict,model,nns,costs,inp,inp_out_dict,max_len,batch_size,to_do,forward_outs):
+        if not dry_run:
+            outs_dict = forward_model(fea_dict,lab_dict,arch_dict,model,nns,costs,inp,inp_out_dict,max_len,batch_size,to_do,forward_outs)
+        else:
+            outs_dict = dict()
+        return outs_dict
+    def _optimization_step(optimizers, outs_dict, config, arch_dict):
+        for opt in optimizers.keys():
+            optimizers[opt].zero_grad()
+        outs_dict['loss_final'].backward()
+        for opt in optimizers.keys():
+            if not(strtobool(config[arch_dict[opt][0]]['arch_freeze'])):
+                optimizers[opt].step()
+    def _update_progress_bar(to_do, i, N_batches, loss_sum):
+        if to_do == 'train':
+            status_string="Training | (Batch "+str(i+1)+"/"+str(N_batches)+")"+" | L:" +str(round(loss_sum.cpu().item()/(i+1),3))
+            if i==N_batches-1:
+                status_string="Training | (Batch "+str(i+1)+"/"+str(N_batches)+")"
+        if to_do == 'valid':
+            status_string="Validating | (Batch "+str(i+1)+"/"+str(N_batches)+")"
+        if to_do == 'forward':
+            status_string="Forwarding | (Batch "+str(i+1)+"/"+str(N_batches)+")"
+        progress(i, N_batches, status=status_string)
+    def _write_info_file(info_file, to_do, loss_tot, err_tot, elapsed_time_chunk):
+        with open(info_file, "w") as text_file:
+            text_file.write("[results]\n")
+            if to_do!='forward':
+                text_file.write("loss=%s\n" % loss_tot.cpu().numpy())
+                text_file.write("err=%s\n" % err_tot.cpu().numpy())
+            text_file.write("elapsed_time_chunk=%f\n" % elapsed_time_chunk)
+        text_file.close()
+    def _save_model(to_do, nns, multi_gpu, optimizers, info_file, arch_dict):
+        if to_do=='train':
+             for net in nns.keys():
+                 checkpoint={}
+                 if multi_gpu:
+                     checkpoint['model_par']=nns[net].module.state_dict()
+                 else:
+                     checkpoint['model_par']=nns[net].state_dict()
+                 checkpoint['optimizer_par']=optimizers[net].state_dict()
+                 out_file=info_file.replace('.info','_'+arch_dict[net][0]+'.pkl')
+                 torch.save(checkpoint, out_file)
+    
+    config = _read_chunk_specific_config(cfg_file)
+    _initialize_random_seed(config)
+    
+    output_folder = config['exp']['out_folder']
+    use_cuda = strtobool(config['exp']['use_cuda'])
+    multi_gpu = strtobool(config['exp']['multi_gpu'])
+    to_do = config['exp']['to_do']
+    info_file = config['exp']['out_info']
+    model = config['model']['model'].split('\n')
+    forward_outs = config['forward']['forward_out'].split(',')
+    forward_normalize_post = list(map(strtobool,config['forward']['normalize_posteriors'].split(',')))
+    forward_count_files = config['forward']['normalize_with_counts_from'].split(',')
+    require_decodings = list(map(strtobool,config['forward']['require_decoding'].split(',')))
+    save_gpumem = strtobool(config['exp']['save_gpumem'])
+    is_production = strtobool(config['exp']['production'])
+    batch_size = _get_batch_size_from_config(config, to_do)
+
+    if processed_first:
+        shared_list = list()
+        p = _read_next_chunk_into_shared_list_with_subprocess(read_lab_fea, shared_list, cfg_file, is_production, output_folder, wait_for_process=True)
+        data_name, data_end_index, fea_dict, lab_dict, arch_dict, data_set = _extract_data_from_shared_list(shared_list)
+        data_set = _convert_numpy_to_torch(data_set, save_gpumem, use_cuda)
+    shared_list = list()
+    data_loading_process = _read_next_chunk_into_shared_list_with_subprocess(read_lab_fea, shared_list, next_config_file, is_production, output_folder, wait_for_process=False)
+    nns, costs, optimizers, inp_out_dict = _load_model_and_optimizer(fea_dict,model,config,arch_dict,use_cuda,multi_gpu,to_do)
+    if to_do=='forward':
+        post_file = _open_forward_output_files_and_get_file_handles(forward_outs, require_decodings, info_file, output_folder)
+    
+    seq_model = is_sequential_dict(config,arch_dict)
+    N_snt, N_ex_tr, N_batches = _get_batch_config(data_set, seq_model, to_do, data_name, batch_size) 
+    beg_batch = 0
+    end_batch = batch_size 
+    snt_index = 0
+    beg_snt = 0 
+    arr_snt_len = shift(shift(data_end_index, -1,0)-data_end_index,1,0)
+    arr_snt_len[0] = data_end_index[0]
+    inp_dim = data_set.shape[1]
+    loss_sum = 0
+    err_sum = 0
+    start_time = time.time()
+    for i in range(N_batches):
+        inp, max_len, snt_len, beg_snt, snt_index = _prepare_input(snt_index, batch_size, inp_dim, beg_snt, data_end_index, beg_batch, end_batch, seq_model, arr_snt_len, data_set, use_cuda)
+        if dry_run:
+            outs_dict = dict()
+        else:
+            if to_do=='train':
+                outs_dict = forward_model(fea_dict, lab_dict, arch_dict, model, nns, costs, inp, inp_out_dict, max_len, batch_size, to_do, forward_outs)
+                _optimization_step(optimizers, outs_dict, config, arch_dict)
+            else:
+                with torch.no_grad():
+                    outs_dict = forward_model(fea_dict, lab_dict, arch_dict, model, nns, costs, inp, inp_out_dict, max_len, batch_size, to_do, forward_outs)
+            if to_do == 'forward':
+                for out_id in range(len(forward_outs)):
+                    out_save = outs_dict[forward_outs[out_id]].data.cpu().numpy()
+                    if forward_normalize_post[out_id]:
+                        counts = load_counts(forward_count_files[out_id])
+                        out_save=out_save-np.log(counts/np.sum(counts))             
+                    write_mat(output_folder,post_file[forward_outs[out_id]], out_save, data_name[i])
+            else:
+                loss_sum=loss_sum+outs_dict['loss_final'].detach()
+                err_sum=err_sum+outs_dict['err_final'].detach()
+        beg_batch=end_batch
+        end_batch=beg_batch+batch_size
+        _update_progress_bar(to_do, i, N_batches, loss_sum)
+    elapsed_time_chunk=time.time() - start_time 
+    loss_tot=loss_sum/N_batches
+    err_tot=err_sum/N_batches
+    del inp, outs_dict, data_set
+    _save_model(to_do, nns, multi_gpu, optimizers, info_file, arch_dict)
+    if to_do=='forward':
+        for out_name in forward_outs:
+            post_file[out_name].close()
+    _write_info_file(info_file, to_do, loss_tot, err_tot, elapsed_time_chunk)
+    if not data_loading_process is None:
+        data_loading_process.join()
+    data_name, data_end_index, fea_dict, lab_dict, arch_dict, data_set = _extract_data_from_shared_list(shared_list)
+    data_set = _convert_numpy_to_torch(data_set, save_gpumem, use_cuda)
+    return [data_name,data_set,data_end_index,fea_dict,lab_dict,arch_dict]
+
 def run_nn(data_name,data_set,data_end_index,fea_dict,lab_dict,arch_dict,cfg_file,processed_first,next_config_file,dry_run=False):
     
     # This function processes the current chunk using the information in cfg_file. In parallel, the next chunk is load into the CPU memory

--- a/utils.py
+++ b/utils.py
@@ -1792,7 +1792,7 @@ def optimizer_init(nns,config,arch_dict):
     return optimizers
 
 
-def forward_model_refac01(fea_dict,lab_dict,arch_dict,model,nns,costs,inp,inp_out_dict,max_len,batch_size,to_do,forward_outs):
+def forward_model_refac01(fea_dict,lab_dict,arch_dict,model,nns,costs,inp,ref,inp_out_dict,max_len,batch_size,to_do,forward_outs):
     def _add_input_features_to_outs_dict(fea_dict, outs_dict, inp):
         for fea in fea_dict.keys():
             if len(inp.shape)==3 and len(fea_dict[fea])>1:
@@ -1842,6 +1842,7 @@ def forward_model_refac01(fea_dict,lab_dict,arch_dict,model,nns,costs,inp,inp_ou
             out=out.view(max_len*batch_size,-1)
         return out
 
+    inp = torch.cat((inp, ref), -1)
     outs_dict={}
     _add_input_features_to_outs_dict(fea_dict, outs_dict, inp)
     layer_string_pattern='(.*)=(.*)\((.*),(.*)\)'

--- a/utils.py
+++ b/utils.py
@@ -1792,6 +1792,108 @@ def optimizer_init(nns,config,arch_dict):
     return optimizers
 
 
+def forward_model_refac01(fea_dict,lab_dict,arch_dict,model,nns,costs,inp,inp_out_dict,max_len,batch_size,to_do,forward_outs):
+    def _add_input_features_to_outs_dict(fea_dict, outs_dict, inp):
+        for fea in fea_dict.keys():
+            if len(inp.shape)==3 and len(fea_dict[fea])>1:
+                outs_dict[fea]=inp[:,:,fea_dict[fea][5]:fea_dict[fea][6]]
+            if len(inp.shape)==2 and len(fea_dict[fea])>1:
+                outs_dict[fea]=inp[:,fea_dict[fea][5]:fea_dict[fea][6]]
+        return outs_dict
+    def _compute_layer_values(inp_out_dict, inp2, inp, inp1, max_len, batch_size, arch_dict, out_name, nns, outs_dict, to_do):
+        def _is_input_feature(inp_out_dict, inp2):
+            if len(inp_out_dict[inp2])>1:
+                return True
+            return False
+        def _extract_respective_feature_from_input(inp, inp_out_dict, inp2, arch_dict, inp1, max_len, batch_size):
+            if len(inp.shape)==3:
+                inp_dnn=inp[:,:,inp_out_dict[inp2][-3]:inp_out_dict[inp2][-2]]
+                if not(bool(arch_dict[inp1][2])):
+                    inp_dnn=inp_dnn.view(max_len*batch_size,-1)
+            if len(inp.shape)==2:
+                inp_dnn=inp[:,inp_out_dict[inp2][-3]:inp_out_dict[inp2][-2]]
+                if bool(arch_dict[inp1][2]):
+                    inp_dnn=inp_dnn.view(max_len,batch_size,-1)
+            return inp_dnn
+        
+        do_break = False
+        if _is_input_feature(inp_out_dict, inp2):
+            inp_dnn = _extract_respective_feature_from_input(inp, inp_out_dict, inp2, arch_dict, inp1, max_len, batch_size)
+            outs_dict[out_name]=nns[inp1](inp_dnn)
+        else:
+            if not(bool(arch_dict[inp1][2])) and len(outs_dict[inp2].shape)==3:
+                outs_dict[inp2]=outs_dict[inp2].view(max_len*batch_size,-1)
+            if bool(arch_dict[inp1][2]) and len(outs_dict[inp2].shape)==2:
+                outs_dict[inp2]=outs_dict[inp2].view(max_len,batch_size,-1)
+            outs_dict[out_name]=nns[inp1](outs_dict[inp2])
+        if to_do=='forward' and out_name==forward_outs[-1]:
+            do_break = True
+        return outs_dict, do_break
+    def _get_labels_from_input(inp, inp2, lab_dict):
+        if len(inp.shape)==3:
+            lab_dnn=inp[:,:,lab_dict[inp2][3]]
+        if len(inp.shape)==2:
+            lab_dnn=inp[:,lab_dict[inp2][3]]
+        lab_dnn=lab_dnn.view(-1).long()
+        return lab_dnn
+    def _get_network_output(outs_dict, inp1, max_len, batch_size):
+        out=outs_dict[inp1]
+        if len(out.shape)==3:
+            out=out.view(max_len*batch_size,-1)
+        return out
+
+    outs_dict={}
+    _add_input_features_to_outs_dict(fea_dict, outs_dict, inp)
+    layer_string_pattern='(.*)=(.*)\((.*),(.*)\)'
+    for line in model:
+        out_name, operation, inp1, inp2 = list(re.findall(layer_string_pattern,line)[0])
+        if operation == 'compute':
+            outs_dict, do_break = _compute_layer_values(inp_out_dict, inp2, inp, inp1, max_len, batch_size, arch_dict, out_name, nns, outs_dict, to_do)
+            if do_break:
+                break
+        elif operation == 'cost_nll':
+            lab_dnn = _get_labels_from_input(inp, inp2, lab_dict)
+            out = _get_network_output(outs_dict, inp1, max_len, batch_size)
+            if to_do != 'forward':
+                outs_dict[out_name]=costs[out_name](out, lab_dnn)
+        elif operation == 'cost_err':
+            lab_dnn = _get_labels_from_input(inp, inp2, lab_dict)
+            out = _get_network_output(outs_dict, inp1, max_len, batch_size)
+            if to_do != 'forward':
+                pred = torch.max(out,dim=1)[1] 
+                err = torch.mean((pred!=lab_dnn).float())
+                outs_dict[out_name]=err
+        elif operation == 'concatenate':
+            dim_conc = len(outs_dict[inp1].shape)-1
+            outs_dict[out_name] = torch.cat((outs_dict[inp1],outs_dict[inp2]),dim_conc) #check concat axis
+            if to_do == 'forward' and out_name == forward_outs[-1]:
+                break
+        elif operation == 'mult':
+            outs_dict[out_name] = outs_dict[inp1] * outs_dict[inp2]
+            if to_do == 'forward' and out_name == forward_outs[-1]:
+                break
+        elif operation == 'sum':
+            outs_dict[out_name] = outs_dict[inp1] + outs_dict[inp2] 
+            if to_do == 'forward' and out_name == forward_outs[-1]:
+                break
+        elif operation == 'mult_constant':
+            outs_dict[out_name] = outs_dict[inp1] * float(inp2)
+            if to_do == 'forward' and out_name == forward_outs[-1]:
+                break
+        elif operation == 'sum_constant':
+            outs_dict[out_name] = outs_dict[inp1] + float(inp2)
+            if to_do == 'forward' and out_name == forward_outs[-1]:
+                break
+        elif operation == 'avg':
+            outs_dict[out_name] = (outs_dict[inp1] + outs_dict[inp2])/2
+            if to_do == 'forward' and out_name == forward_outs[-1]:
+                break
+        elif operation == 'mse':
+            outs_dict[out_name] = torch.mean((outs_dict[inp1] - outs_dict[inp2]) ** 2)
+            if to_do == 'forward' and out_name == forward_outs[-1]:
+                break
+    return  outs_dict
+
 
 def forward_model(fea_dict,lab_dict,arch_dict,model,nns,costs,inp,inp_out_dict,max_len,batch_size,to_do,forward_outs):
     


### PR DESCRIPTION
This pull request refactors run_nn, read_lab_fea and forward_model.

The resulting functions have the same functionality as the previous implementations, but are kept in separated *_refac01 functions for now until more detailed tests have been done.
The functions can be used by setting the config option exp->run_nn_script=run_nn_refac01

The interfaces between the three functions has been changed, such that features and labels are not concatenated, but treated as separate sequences. This allows the input and label sequence to have different time dimensions as e.g. if the input is the raw time signal and the network is doing the subsampling in time.