### PR TITLE
limit forwarding subprocesses

### DIFF
--- a/data_io.py
+++ b/data_io.py
@@ -305,9 +305,9 @@ def read_lab_fea_refac01(cfg_file, fea_only, shared_list, output_folder):
                 fea_index=fea_index+data_set_fea.shape[1]
                 fea_dict[fea].append(fea_index)
                 fea_dict[fea].append(fea_dict[fea][6]-fea_dict[fea][5])
-            elif cnt_fea==0 and (not cnt_fea==0):
+            elif cnt_fea==0 and (not cnt_lab==0):
                 labs=np.column_stack((labs,labs_fea))
-            elif (not cnt_fea==0) and cnt_fea==0:
+            elif (not cnt_fea==0) and cnt_lab==0:
                 data_set=np.column_stack((data_set,data_set_fea))
                 fea_dict[fea].append(fea_index)
                 fea_index=fea_index+data_set_fea.shape[1]

--- a/data_io.py
+++ b/data_io.py
@@ -368,12 +368,13 @@ def read_lab_fea_refac01(cfg_file, fea_only, shared_list, output_folder):
             for lab in lab_dict.keys():
                 lab_folder, lab_opts = _get_lab_config_from_dict(lab_dict[lab], fea_only)
                 data_name_fea, data_set_fea, data_set_lab, data_end_index_fea, data_end_index_lab = _load_chunk_refac01(fea_scp, fea_opts, lab_folder, lab_opts, cw_left, cw_right, max_seq_length, output_folder, fea_only)
-                labs_fea, data_set_fea, data_end_index_fea, data_end_index_lab = _compensate_for_different_context_windows(data_set_fea, data_set_lab, cw_left_max, cw_left, cw_right_max, cw_right, data_end_index_fea, data_end_index_lab)
+                if sum([abs(e) for e in [cw_left_max, cw_right_max, cw_left, cw_right]]) != 0: 
+                    data_set_lab, data_set_fea, data_end_index_fea, data_end_index_lab = _compensate_for_different_context_windows(data_set_fea, data_set_lab, cw_left_max, cw_left, cw_right_max, cw_right, data_end_index_fea, data_end_index_lab)
                 if cnt_fea == 0 and cnt_lab == 0:
                     data_end_index_fea_ini = data_end_index_fea
                     data_end_index_lab_ini = data_end_index_lab
                     data_name = data_name_fea
-                data_set, labs, fea_dict, fea_index = _update_data(data_set, labs, fea_dict, fea, fea_index, data_set_fea, labs_fea, cnt_fea, cnt_lab)
+                data_set, labs, fea_dict, fea_index = _update_data(data_set, labs, fea_dict, fea, fea_index, data_set_fea, data_set_lab, cnt_fea, cnt_lab)
                 _check_consistency(data_name, data_name_fea, data_end_index_fea_ini, data_end_index_fea, data_end_index_lab_ini, data_end_index_lab)
                 cnt_lab=cnt_lab+1
             cnt_fea=cnt_fea+1

--- a/proto/channelAvg.proto
+++ b/proto/channelAvg.proto
@@ -1,0 +1,4 @@
+[proto]
+chAvg_channelWeights=str
+
+

--- a/run_exp.py
+++ b/run_exp.py
@@ -45,6 +45,11 @@ def _is_first_validation(ck, N_ck_tr, config):
         return True
     return False
 
+def _max_nr_of_parallel_forwarding_processes(config):
+    if 'max_nr_of_parallel_forwarding_processes' in config['forward']:
+        return int(config['forward']['max_nr_of_parallel_forwarding_processes'])
+    return -1
+
 # Reading global cfg file (first argument-mandatory file) 
 cfg_file=sys.argv[1]
 if not(os.path.exists(cfg_file)):
@@ -332,6 +337,9 @@ for forward_data in forward_data_lst:
                     data_end_index = {'fea': data_end_index_fea,'lab': data_end_index_lab}
                     p = multiprocessing.Process(target=run_nn, kwargs={'data_name': data_name, 'data_set': data_set, 'data_end_index': data_end_index, 'fea_dict': fea_dict, 'lab_dict': lab_dict, 'arch_dict': arch_dict, 'cfg_file': config_chunk_file, 'processed_first': False, 'next_config_file': None})
                     processes.append(p)
+                    if _max_nr_of_parallel_forwarding_processes(config) != -1 and len(processes) > _max_nr_of_parallel_forwarding_processes(config):
+                        processes[0].join()
+                        del processes[0]
                     p.start()
                 else:
                     [data_name,data_set,data_end_index,fea_dict,lab_dict,arch_dict]=run_nn(data_name,data_set,data_end_index,fea_dict,lab_dict,arch_dict,config_chunk_file,processed_first,next_config_file)

--- a/utils.py
+++ b/utils.py
@@ -934,6 +934,12 @@ def create_lists(config):
         random.shuffle(full_list_fea_conc)
         valid_chunks_fea=list(split_chunks(full_list_fea_conc,N_chunks))
         return valid_chunks_fea
+    def _shuffle_forward_data(config):
+        if 'shuffle_forwarding_data' in config['forward']:
+            suffle_on_forwarding = strtobool(config['forward']['shuffle_forwarding_data'])
+            if not suffle_on_forwarding:
+                return False
+        return True
     
     # splitting data into chunks (see out_folder/additional_files)
     out_folder=config['exp']['out_folder']
@@ -1030,7 +1036,8 @@ def create_lists(config):
             
          
         # randomize the list
-        random.shuffle(full_list_fea_conc)
+        if _shuffle_forward_data(config):
+            random.shuffle(full_list_fea_conc)
         forward_chunks_fea=list(split_chunks(full_list_fea_conc,N_chunks))
 
         


### PR DESCRIPTION
Limits the number of subprocesses.
This is necessary if the dataset is large and processing the complete dataset in parallel would exhaust the memory.

This allows to benefit from speed up by parallelization (e.g. using 16 CPUS) but still staying within the memory limits